### PR TITLE
replace deprecated lib with new

### DIFF
--- a/dist/createAsyncStorage.js
+++ b/dist/createAsyncStorage.js
@@ -39,7 +39,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-var async_storage_1 = __importDefault(require("@react-native-community/async-storage"));
+var async_storage_1 = __importDefault(require("@react-native-async-storage/async-storage"));
 var noop = function () { return null; };
 var createAsyncStorage = function () {
     return {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react-native": ">=0.59.0"
   },
   "dependencies": {
-    "@react-native-community/async-storage": "^1.7.1",
+    "@react-native-async-storage/async-storage": "^1.14.1",
     "react-native-sensitive-info": "^5.5.4"
   },
   "devDependencies": {
@@ -55,7 +55,9 @@
     "typescript": "^3.7.3"
   },
   "jest": {
-    "setupFiles": ["./tests/setup.ts"],
+    "setupFiles": [
+      "./tests/setup.ts"
+    ],
     "transformIgnorePatterns": [
       "node_modules/(?!(@react-native-community|react-native)/)"
     ]

--- a/src/createAsyncStorage.ts
+++ b/src/createAsyncStorage.ts
@@ -1,4 +1,3 @@
-// import asyncStorage from '@react-native-community/async-storage';
 import asyncStorage from '@react-native-async-storage/async-storage';
 
 type TValue = string | null;

--- a/src/createAsyncStorage.ts
+++ b/src/createAsyncStorage.ts
@@ -1,4 +1,5 @@
-import asyncStorage from '@react-native-community/async-storage';
+// import asyncStorage from '@react-native-community/async-storage';
+import asyncStorage from '@react-native-async-storage/async-storage';
 
 type TValue = string | null;
 

--- a/tests/__mocks__/@react-native-community/async-storage.js
+++ b/tests/__mocks__/@react-native-community/async-storage.js
@@ -1,2 +1,2 @@
-import mockStorage from '@react-native-community/async-storage/jest/async-storage-mock';
+import mockStorage from '@react-native-async-storage/async-storage/jest/async-storage-mock';
 export default mockStorage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1505,10 +1505,12 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@react-native-community/async-storage@^1.7.1":
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/async-storage/-/async-storage-1.7.1.tgz#ef2104d865de61ad91bba66613e57e689ff4e6a1"
-  integrity sha512-/oX/x+EU4xNaqIaC/epVKzO8XghzImPA7l8cLz3USEFmtFiXFjBbTeeIFjjEm/u4/cv38Wi1xMEa10PHIWygRg==
+"@react-native-async-storage/async-storage@^1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.14.1.tgz#3c2ff2b1a312df3b1c809a60fa88665e50a095b8"
+  integrity sha512-UkLUox2q5DKNYB6IMUzsuwrTJeXGLySvtQlnrqd3fd+96JErCT4X3xD+W1cvQjes0nm0LbaELbwObKc+Tea7wA==
+  dependencies:
+    deep-assign "^3.0.0"
 
 "@react-native-community/cli-debugger-ui@^3.0.0":
   version "3.0.0"
@@ -2691,6 +2693,13 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
+deep-assign@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/deep-assign/-/deep-assign-3.0.0.tgz#c8e4c4d401cba25550a2f0f486a2e75bc5f219a2"
+  integrity sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==
+  dependencies:
+    is-obj "^1.0.0"
+
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
@@ -3641,6 +3650,11 @@ is-number@^3.0.0:
   integrity sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=
   dependencies:
     kind-of "^3.0.2"
+
+is-obj@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
 
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"


### PR DESCRIPTION
@react-native-community/async-storage has been deprecated and the new org [React Native Async Storage](https://github.com/react-native-async-storage/async-storage#readme) has taken over.
This replaces the deprecated lib with the new one.