### PR TITLE
Feature: resetState method

### DIFF
--- a/src/usePersistStorage.ts
+++ b/src/usePersistStorage.ts
@@ -44,7 +44,12 @@ const usePersistStorage = <Value>(
     migrate = defaultOptions.migrate,
     sensitive = defaultOptions.sensitive
   }: UsePersistStorageOptions<Value> = defaultOptions
-): [Value, AsyncSetState<Value>, boolean] => {
+): [
+    Value,
+    AsyncSetState<Value>,
+    boolean,
+    () => Promise<void>
+  ] => {
   const currentVersion = useRef<number>(version || 0);
   const [state, setState] = useState<Value>(initialValue);
   const [restored, setRestored] = useState<boolean>(false);
@@ -148,7 +153,15 @@ const usePersistStorage = <Value>(
     }
   };
 
-  return [state, asyncSetState, restored];
+  const resetState = async () => {
+    const newValue: Value =
+      initialValue instanceof Function
+        ? initialValue()
+        : initialValue;
+    await asyncSetState(newValue);
+  }
+
+  return [state, asyncSetState, restored, resetState];
 };
 
 export default usePersistStorage;


### PR DESCRIPTION
The resetting method would be very useful when we want to reset the state to the initial values
 in the scenario where we want to log out an user or cleanup the data

- [x] tests covered

## Usage
```
[myData, setMyData, restored, resetMyData] = usePersistStorage('@TheKey', () => { 'MyData' })
console.log(myData); // 'My data'

setMyData('New data')
console.log(myData); // 'New data'
setMyData('Other data')
console.log(myData); // 'Other data'

resetMyData();
console.log(myData); // 'My data'
```